### PR TITLE
[WC-25]  refactor: HomePage에서 Tab관련 로직 정리

### DIFF
--- a/src/components/molecule/Tab/Tab.jsx
+++ b/src/components/molecule/Tab/Tab.jsx
@@ -1,10 +1,98 @@
 import React from 'react';
-import { useState, useMemo } from 'react';
+// import { useState, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
-import { rgba } from 'polished';
+// import { rgba } from 'polished';
 import Common from '@styles';
 import TabItem from './TabItem';
+
+// const childrenToArray = (children, types) => {
+//   return React.Children.toArray(children).filter(element => {
+//     if (React.isValidElement(element) && types.includes(element.props.__TYPE)) {
+//       return true;
+//     } else {
+//       console.warn(
+//         `Only accepts ${
+//           Array.isArray(types) ? types.join(', ') : types
+//         } as it's children.`,
+//       );
+//       return false;
+//     }
+//   });
+// };
+
+const Tab = ({
+  height = 47,
+  backgroundColor = Common.colors.background_menu,
+  pointColor = Common.colors.primary,
+  shadowStyle = Common.shadow.menu,
+  fontSize = Common.fontSize.medium,
+  onClick,
+  ...props
+}) => {
+  // const currentUrlArr = window.location.pathname.split('/');
+
+  // const [currentActive, setCurrentActive] = useState(() => {
+  //   if (
+  //     currentUrlArr.includes('today') ||
+  //     currentUrlArr.includes('my') ||
+  //     currentUrlArr.includes('like')
+  //   ) {
+  //     const currentActiveElement = childrenToArray(children, 'Tab.Item').filter(
+  //       element => currentUrlArr.includes(element.props.param),
+  //     );
+  //     return currentActiveElement[0].props.index;
+  //   } else {
+  //     const index = childrenToArray(children, 'Tab.Item')[0].props.index;
+  //     return index;
+  //   }
+  // });
+
+  // const items = useMemo(() => {
+  //   return childrenToArray(children, 'Tab.Item').map(element => {
+  //     return React.cloneElement(element, {
+  //       ...props,
+  //       ...element.props,
+  //       key: element.props.index,
+  //       active: element.props.index === currentActive,
+  //       height,
+  //       pointColor,
+  //       fontSize,
+  //       onClick: () => {
+  //         setCurrentActive(element.props.index);
+  //       },
+  //     });
+  //   });
+  // }, [children, currentActive, fontSize, height, pointColor, props]);
+
+  return (
+    <TabItemContainer
+      backgroundColor={backgroundColor}
+      shadowStyle={shadowStyle}
+      {...props}>
+      <TabItem title="오늘의 카드" name="total" onClick={onClick}></TabItem>
+      <TabItem title="나의 카드" name="my" onClick={onClick}></TabItem>
+      <TabItem title="관심 카드" name="like" onClick={onClick}></TabItem>
+      {/* <TabItemPointer
+        currentActive={currentActive}
+        height={height}
+        backgroundColor={backgroundColor}
+        shadowStyle={shadowStyle}
+        pointColor={pointColor}
+        {...props}></TabItemPointer> */}
+    </TabItemContainer>
+  );
+};
+
+Tab.propTypes = {
+  activeItemIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  height: PropTypes.number,
+  backgroundColor: PropTypes.string,
+  pointColor: PropTypes.string,
+  shadowStyle: PropTypes.string,
+  fontSize: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  onClick: PropTypes.func,
+};
 
 const TabItemContainer = styled.div`
   position: relative;
@@ -19,110 +107,22 @@ const TabItemContainer = styled.div`
   box-shadow: ${({ shadowStyle }) => shadowStyle};
 `;
 
-const TabItemPointer = styled.div`
-  position: absolute;
-  top: 0;
-  transform: ${({ currentActive }) =>
-    currentActive && `translate(${currentActive * 100}%, 0)`};
-  width: calc(100% / 3);
-  height: ${({ height }) => `${height}px`};
-  min-height: 25px;
-  border: ${({ pointColor }) => `1px solid ${pointColor}`};
-  border-radius: 50px;
-  background-color: ${({ backgroundColor }) => rgba(backgroundColor, 0.2)};
-  box-shadow: ${({ shadowStyle }) => shadowStyle};
-  transition: transform 0.2s ease-out;
-  @media ${Common.media.sm} {
-    height: ${({ height }) => `${height * 0.68}px`};
-  }
-`;
-
-const childrenToArray = (children, types) => {
-  return React.Children.toArray(children).filter(element => {
-    if (React.isValidElement(element) && types.includes(element.props.__TYPE)) {
-      return true;
-    } else {
-      console.warn(
-        `Only accepts ${
-          Array.isArray(types) ? types.join(', ') : types
-        } as it's children.`,
-      );
-      return false;
-    }
-  });
-};
-
-const Tab = ({
-  children,
-  height = 47,
-  backgroundColor = Common.colors.background_menu,
-  pointColor = Common.colors.primary,
-  shadowStyle = Common.shadow.menu,
-  fontSize = Common.fontSize.medium,
-  ...props
-}) => {
-  const currentUrlArr = window.location.pathname.split('/');
-
-  const [currentActive, setCurrentActive] = useState(() => {
-    if (
-      currentUrlArr.includes('today') ||
-      currentUrlArr.includes('my') ||
-      currentUrlArr.includes('like')
-    ) {
-      const currentActiveElement = childrenToArray(children, 'Tab.Item').filter(
-        element => currentUrlArr.includes(element.props.param),
-      );
-      return currentActiveElement[0].props.index;
-    } else {
-      const index = childrenToArray(children, 'Tab.Item')[0].props.index;
-      return index;
-    }
-  });
-
-  const items = useMemo(() => {
-    return childrenToArray(children, 'Tab.Item').map(element => {
-      return React.cloneElement(element, {
-        ...props,
-        ...element.props,
-        key: element.props.index,
-        active: element.props.index === currentActive,
-        height,
-        pointColor,
-        fontSize,
-        onClick: () => {
-          setCurrentActive(element.props.index);
-        },
-      });
-    });
-  }, [children, currentActive, fontSize, height, pointColor, props]);
-
-  return (
-    <TabItemContainer
-      backgroundColor={backgroundColor}
-      shadowStyle={shadowStyle}
-      {...props}>
-      {items}
-      <TabItemPointer
-        currentActive={currentActive}
-        height={height}
-        backgroundColor={backgroundColor}
-        shadowStyle={shadowStyle}
-        pointColor={pointColor}
-        {...props}></TabItemPointer>
-    </TabItemContainer>
-  );
-};
-
-Tab.Item = TabItem;
-
-Tab.propTypes = {
-  children: PropTypes.node.isRequired,
-  activeItemIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-  height: PropTypes.number,
-  backgroundColor: PropTypes.string,
-  pointColor: PropTypes.string,
-  shadowStyle: PropTypes.string,
-  fontSize: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-};
+// const TabItemPointer = styled.div`
+//   position: absolute;
+//   top: 0;
+//   transform: ${({ currentActive }) =>
+//     currentActive && `translate(${currentActive * 100}%, 0)`};
+//   width: calc(100% / 3);
+//   height: ${({ height }) => `${height}px`};
+//   min-height: 25px;
+//   border: ${({ pointColor }) => `1px solid ${pointColor}`};
+//   border-radius: 50px;
+//   background-color: ${({ backgroundColor }) => rgba(backgroundColor, 0.2)};
+//   box-shadow: ${({ shadowStyle }) => shadowStyle};
+//   transition: transform 0.2s ease-out;
+//   @media ${Common.media.sm} {
+//     height: ${({ height }) => `${height * 0.68}px`};
+//   }
+// `;
 
 export default Tab;

--- a/src/components/molecule/Tab/TabItem.jsx
+++ b/src/components/molecule/Tab/TabItem.jsx
@@ -3,6 +3,47 @@ import PropTypes from 'prop-types';
 import Common from '@styles';
 import { rgba } from 'polished';
 
+const TabItem = ({
+  title,
+  name,
+  active,
+  height,
+  pointColor,
+  fontSize,
+  onClick,
+  ...props
+}) => {
+  const handleClick = () => {
+    onClick && onClick(name);
+  };
+  return (
+    <TabItemWrapper active={active} onClick={handleClick} {...props}>
+      <LinkBox>
+        <TabItemTitle
+          active={active}
+          pointColor={pointColor}
+          fontSize={fontSize}
+          height={height}
+          {...props}>
+          {title}
+        </TabItemTitle>
+      </LinkBox>
+    </TabItemWrapper>
+  );
+};
+
+TabItem.defaultProps = {
+  active: false,
+  onClick: () => {},
+};
+
+TabItem.propTypes = {
+  title: PropTypes.string.isRequired,
+  active: PropTypes.bool,
+  onClick: PropTypes.func,
+  name: PropTypes.string.isRequired,
+};
+
 const TabItemWrapper = styled.div`
   display: flex;
   align-items: center;
@@ -26,7 +67,7 @@ const TabItemTitle = styled.span`
   font-weight: ${({ active }) =>
     active ? Common.fontWeight.bold : Common.fontWeight.regular};
   color: ${({ active, pointColor }) =>
-    active ? pointColor : rgba(pointColor, 0.35)};
+    active ? pointColor : rgba(255, 205, 100, 0.75)};
   transition: color 0.2s ease-out;
   z-index: 1;
   @media ${Common.media.sm} {
@@ -38,42 +79,5 @@ const LinkBox = styled.div`
   display: block;
   width: 100%;
 `;
-
-const TabItem = ({
-  title,
-  index,
-  param,
-  active,
-  height,
-  pointColor,
-  fontSize,
-  ...props
-}) => {
-  return (
-    <TabItemWrapper active={active} {...props}>
-      <LinkBox>
-        <TabItemTitle
-          active={active}
-          pointColor={pointColor}
-          fontSize={fontSize}
-          height={height}
-          {...props}>
-          {title}
-        </TabItemTitle>
-      </LinkBox>
-    </TabItemWrapper>
-  );
-};
-
-TabItem.defaultProps = {
-  __TYPE: 'Tab.Item',
-};
-
-TabItem.propTypes = {
-  __TYPE: PropTypes.oneOf(['Tab.Item']),
-  title: PropTypes.string.isRequired,
-  index: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
-  active: PropTypes.bool,
-};
 
 export default TabItem;

--- a/src/pages/HomePage/index.jsx
+++ b/src/pages/HomePage/index.jsx
@@ -8,23 +8,10 @@ import Swal from 'sweetalert2';
 import { parseCardInfo } from '@utils';
 import { useUser } from '@contexts';
 
-const HomeContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  width: 100%;
-  padding: 10px 50px;
-  @media ${Common.media.sm} {
-    padding: 10px 16px;
-  }
-  height: calc(100vh - 60px);
-  margin: 0 auto;
-`;
-
 const HomePage = () => {
   const { userInfo } = useUser();
   const [cardList, setCardList] = useState([]);
-  const [currentParam, setCurrentParam] = useState('');
+  const [cardListName, setCardListName] = useState('');
   const [isLoading, setIsLoading] = useState(false);
 
   const getTodayCardList = useCallback(async () => {
@@ -93,49 +80,40 @@ const HomePage = () => {
 
   useEffect(() => {
     const init = async () => {
-      const currentUrlArr = window.location.pathname.split('/');
-      setCurrentParam(() => {
-        return currentUrlArr[currentUrlArr.length - 1];
-      });
-
-      if (currentUrlArr.includes('today') || currentUrlArr[1] === '') {
-        getTodayCardList();
-      } else if (currentUrlArr.includes('my')) {
-        getMyCardList(userInfo?.id);
-      } else if (currentUrlArr.includes('like')) {
-        getBookmarkCardList();
+      if (cardListName === 'total') {
+        await getTodayCardList();
+        console.log(cardListName);
+        return;
+      }
+      if (cardListName === 'my') {
+        await getMyCardList(userInfo?.id);
+        console.log(cardListName);
+        return;
+      }
+      if (cardListName === 'like') {
+        await getBookmarkCardList();
+        console.log(cardListName);
+        return;
       }
     };
     setIsLoading(true);
     init();
     setIsLoading(false);
     // eslint-disable-next-line
-  }, [currentParam]);
+  }, [cardListName]);
 
-  const handleTabClick = () => {
-    setCurrentParam(() => {
-      const currentUrlArr = window.location.pathname.split('/');
-      return currentUrlArr[currentUrlArr.length - 1];
-    });
+  const handleTabClick = name => {
+    setCardListName(name);
   };
 
   return (
     <HomeContainer>
-      <nav>
-        <Tab
-          onClick={() => {
-            handleTabClick();
-          }}>
-          <Tab.Item title="오늘의 카드" index="0" param="today"></Tab.Item>
-          <Tab.Item title="나의 카드" index="1" param="my"></Tab.Item>
-          <Tab.Item title="관심 카드" index="2" param="like"></Tab.Item>
-        </Tab>
-      </nav>
+      <Tab onClick={handleTabClick} />
       <CardsContainer
-        myCard={currentParam === 'my'}
+        myCard={cardListName === 'my'}
         userInfo={userInfo}
         cardList={cardList}
-        currentParam={currentParam}
+        currentParam={cardListName}
       />
       <ScrollGuide class="scroll_guide" />
       <Spinner loading={isLoading} />
@@ -143,4 +121,18 @@ const HomePage = () => {
     </HomeContainer>
   );
 };
+
+const HomeContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  width: 100%;
+  padding: 10px 50px;
+  @media ${Common.media.sm} {
+    padding: 10px 16px;
+  }
+  height: calc(100vh - 60px);
+  margin: 0 auto;
+`;
+
 export default HomePage;


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

HomePage에서 Tab관련 로직 정리

## 🧑‍💻 PR 세부 내용

- Tab컴포넌트 하나로 정리
- TabItem누를 시 name(total, like, my)이 page의 cardListName상태로 전달
- url 관련 코드 제거


*정리만 해놨고 머지 후에 Tab자체 코드랑 스타일 손 볼게요!
