### PR TITLE
[WC-38] refactor: Tab컴포넌트 리팩토링 및 상수, mixin 생성 후 적용

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -25,6 +25,7 @@ module.exports = {
     );
     config.resolve.alias['@apis'] = path.resolve(__dirname, '../src/apis');
     config.resolve.alias['@utils'] = path.resolve(__dirname, '../src/utils');
+    config.resolve.alias['@constants'] = path.resolve(__dirname, '../src/constants');
     return config;
   },
 };

--- a/craco.config.js
+++ b/craco.config.js
@@ -14,6 +14,7 @@ module.exports = {
       '@validators': path.resolve(__dirname, 'src/validators'),
       '@apis': path.resolve(__dirname, 'src/apis'),
       '@utils': path.resolve(__dirname, 'src/utils'),
+      '@constants': path.resolve(__dirname, 'src/constants'),
     },
   },
 };

--- a/src/components/molecule/Tab/Tab.jsx
+++ b/src/components/molecule/Tab/Tab.jsx
@@ -1,97 +1,41 @@
 import React from 'react';
-// import { useState, useMemo } from 'react';
+import { useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
-// import { rgba } from 'polished';
+import { rgba } from 'polished';
 import Common from '@styles';
 import TabItem from './TabItem';
+import { TAB_MENU } from '@constants';
+import { tebItemSize } from '@styles/mixin';
 
-// const childrenToArray = (children, types) => {
-//   return React.Children.toArray(children).filter(element => {
-//     if (React.isValidElement(element) && types.includes(element.props.__TYPE)) {
-//       return true;
-//     } else {
-//       console.warn(
-//         `Only accepts ${
-//           Array.isArray(types) ? types.join(', ') : types
-//         } as it's children.`,
-//       );
-//       return false;
-//     }
-//   });
-// };
+const Tab = ({ currentActive, onClick, ...props }) => {
+  const [activeItem, setActiveItem] = useState(currentActive);
 
-const Tab = ({
-  height = 47,
-  backgroundColor = Common.colors.background_menu,
-  pointColor = Common.colors.primary,
-  shadowStyle = Common.shadow.menu,
-  fontSize = Common.fontSize.medium,
-  onClick,
-  ...props
-}) => {
-  // const currentUrlArr = window.location.pathname.split('/');
-
-  // const [currentActive, setCurrentActive] = useState(() => {
-  //   if (
-  //     currentUrlArr.includes('today') ||
-  //     currentUrlArr.includes('my') ||
-  //     currentUrlArr.includes('like')
-  //   ) {
-  //     const currentActiveElement = childrenToArray(children, 'Tab.Item').filter(
-  //       element => currentUrlArr.includes(element.props.param),
-  //     );
-  //     return currentActiveElement[0].props.index;
-  //   } else {
-  //     const index = childrenToArray(children, 'Tab.Item')[0].props.index;
-  //     return index;
-  //   }
-  // });
-
-  // const items = useMemo(() => {
-  //   return childrenToArray(children, 'Tab.Item').map(element => {
-  //     return React.cloneElement(element, {
-  //       ...props,
-  //       ...element.props,
-  //       key: element.props.index,
-  //       active: element.props.index === currentActive,
-  //       height,
-  //       pointColor,
-  //       fontSize,
-  //       onClick: () => {
-  //         setCurrentActive(element.props.index);
-  //       },
-  //     });
-  //   });
-  // }, [children, currentActive, fontSize, height, pointColor, props]);
+  const handleClickTabItem = name => {
+    setActiveItem(name);
+    onClick && onClick(name);
+  };
 
   return (
-    <TabItemContainer
-      backgroundColor={backgroundColor}
-      shadowStyle={shadowStyle}
-      {...props}>
-      <TabItem title="오늘의 카드" name="total" onClick={onClick}></TabItem>
-      <TabItem title="나의 카드" name="my" onClick={onClick}></TabItem>
-      <TabItem title="관심 카드" name="like" onClick={onClick}></TabItem>
-      {/* <TabItemPointer
-        currentActive={currentActive}
-        height={height}
-        backgroundColor={backgroundColor}
-        shadowStyle={shadowStyle}
-        pointColor={pointColor}
-        {...props}></TabItemPointer> */}
+    <TabItemContainer {...props}>
+      <TabItem
+        title={TAB_MENU[0].title}
+        name={TAB_MENU[0].name}
+        activeItem={activeItem}
+        onClick={handleClickTabItem}></TabItem>
+      <TabItem
+        title={TAB_MENU[1].title}
+        name={TAB_MENU[1].name}
+        activeItem={activeItem}
+        onClick={handleClickTabItem}></TabItem>
+      <TabItem
+        title={TAB_MENU[2].title}
+        name={TAB_MENU[2].name}
+        activeItem={activeItem}
+        onClick={handleClickTabItem}></TabItem>
+      <TabItemPointer currentActive={activeItem} {...props}></TabItemPointer>
     </TabItemContainer>
   );
-};
-
-Tab.propTypes = {
-  activeItemIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-  height: PropTypes.number,
-  backgroundColor: PropTypes.string,
-  pointColor: PropTypes.string,
-  shadowStyle: PropTypes.string,
-  fontSize: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-  onClick: PropTypes.func,
 };
 
 const TabItemContainer = styled.div`
@@ -99,30 +43,39 @@ const TabItemContainer = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
+  width: 100%;
   max-width: 740px;
   min-width: 280px;
   margin: 0 auto;
   border-radius: 50px;
-  background-color: ${({ backgroundColor }) => backgroundColor};
-  box-shadow: ${({ shadowStyle }) => shadowStyle};
+  background-color: ${Common.colors.background_menu};
+  box-shadow: ${Common.shadow.menu};
 `;
 
-// const TabItemPointer = styled.div`
-//   position: absolute;
-//   top: 0;
-//   transform: ${({ currentActive }) =>
-//     currentActive && `translate(${currentActive * 100}%, 0)`};
-//   width: calc(100% / 3);
-//   height: ${({ height }) => `${height}px`};
-//   min-height: 25px;
-//   border: ${({ pointColor }) => `1px solid ${pointColor}`};
-//   border-radius: 50px;
-//   background-color: ${({ backgroundColor }) => rgba(backgroundColor, 0.2)};
-//   box-shadow: ${({ shadowStyle }) => shadowStyle};
-//   transition: transform 0.2s ease-out;
-//   @media ${Common.media.sm} {
-//     height: ${({ height }) => `${height * 0.68}px`};
-//   }
-// `;
+const TabItemPointer = styled.div`
+  ${tebItemSize}
+  position: absolute;
+  top: 0;
+  transform: ${({ currentActive }) =>
+    currentActive &&
+    `translate(${
+      TAB_MENU.findIndex(obj => obj.name === currentActive) * 100
+    }%, 0)`};
+  border: 1px solid ${Common.colors.primary};
+  border-radius: 50px;
+  background-color: ${rgba(Common.colors.background_menu, 0.2)};
+  box-shadow: ${Common.shadow.menu};
+  transition: transform 0.2s ease-out;
+`;
+
+Tab.defaultProps = {
+  currentActive: '',
+  onClick: () => {},
+};
+
+Tab.propTypes = {
+  currentActive: PropTypes.string,
+  onClick: PropTypes.func,
+};
 
 export default Tab;

--- a/src/components/molecule/Tab/Tab.stories.jsx
+++ b/src/components/molecule/Tab/Tab.stories.jsx
@@ -1,39 +1,11 @@
 import { Tab } from '@components';
-import Common from '@styles';
+import { TAB_MENU } from '@constants';
 
 export default {
-  title: 'Component/Domain/Tab',
+  title: 'Component/molecule/Tab',
   component: Tab,
-  argTypes: {
-    backgroundColor: {
-      defaultValue: Common.colors.background_menu,
-      control: { type: 'color' },
-    },
-    height: {
-      defaultValue: 47,
-      control: { type: 'number' },
-    },
-    pointColor: {
-      defaultValue: Common.colors.primary,
-      control: { type: 'color' },
-    },
-    shadowStyle: {
-      defaultValue: Common.shadow.menu,
-      control: { type: 'text' },
-    },
-    fontSize: {
-      defaultValue: Common.fontSize.medium,
-      control: { type: 'number' },
-    },
-  },
 };
 
-export const Default = args => {
-  return (
-    <Tab {...args}>
-      <Tab.Item title="오늘의 카드" index="0"></Tab.Item>
-      <Tab.Item title="나의 카드" index="1"></Tab.Item>
-      <Tab.Item title="즐겨찾기" index="2"></Tab.Item>
-    </Tab>
-  );
+export const Default = () => {
+  return <Tab currentActive={TAB_MENU[0].name}></Tab>;
 };

--- a/src/components/molecule/Tab/TabItem.jsx
+++ b/src/components/molecule/Tab/TabItem.jsx
@@ -2,29 +2,16 @@ import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 import Common from '@styles';
 import { rgba } from 'polished';
+import { tebItemSize } from '@styles/mixin';
 
-const TabItem = ({
-  title,
-  name,
-  active,
-  height,
-  pointColor,
-  fontSize,
-  onClick,
-  ...props
-}) => {
+const TabItem = ({ title, name, activeItem, onClick, ...props }) => {
   const handleClick = () => {
     onClick && onClick(name);
   };
   return (
-    <TabItemWrapper active={active} onClick={handleClick} {...props}>
+    <TabItemWrapper onClick={handleClick} {...props}>
       <LinkBox>
-        <TabItemTitle
-          active={active}
-          pointColor={pointColor}
-          fontSize={fontSize}
-          height={height}
-          {...props}>
+        <TabItemTitle name={name} activeItem={activeItem} {...props}>
           {title}
         </TabItemTitle>
       </LinkBox>
@@ -32,23 +19,11 @@ const TabItem = ({
   );
 };
 
-TabItem.defaultProps = {
-  active: false,
-  onClick: () => {},
-};
-
-TabItem.propTypes = {
-  title: PropTypes.string.isRequired,
-  active: PropTypes.bool,
-  onClick: PropTypes.func,
-  name: PropTypes.string.isRequired,
-};
-
 const TabItemWrapper = styled.div`
+  ${tebItemSize}
   display: flex;
   align-items: center;
   justify-content: center;
-  width: calc(100% / 3);
   min-height: 25px;
   cursor: pointer;
 `;
@@ -56,28 +31,35 @@ const TabItemWrapper = styled.div`
 const TabItemTitle = styled.span`
   display: flex;
   width: 100%;
-  height: ${({ height }) => `${height}px`};
-  @media ${Common.media.sm} {
-    height: ${({ height }) => `${height * 0.68}px`};
-  }
   justify-content: center;
   align-items: center;
-  font-size: ${({ fontSize }) =>
-    typeof fontSize === 'number' ? `${fontSize}px` : fontSize};
-  font-weight: ${({ active }) =>
-    active ? Common.fontWeight.bold : Common.fontWeight.regular};
-  color: ${({ active, pointColor }) =>
-    active ? pointColor : rgba(255, 205, 100, 0.75)};
-  transition: color 0.2s ease-out;
-  z-index: 1;
+  font-size: ${Common.fontSize.medium};
   @media ${Common.media.sm} {
     font-size: ${Common.fontSize.micro};
   }
+  font-weight: ${({ name, activeItem }) =>
+    name === activeItem ? Common.fontWeight.bold : Common.fontWeight.regular};
+  color: ${({ name, activeItem }) =>
+    name === activeItem ? Common.colors.primary : rgba(255, 255, 255, 0.35)};
+  transition: color 0.2s ease-out;
+  z-index: 1;
 `;
 
 const LinkBox = styled.div`
   display: block;
   width: 100%;
 `;
+
+TabItem.defaultProps = {
+  activeItem: '',
+  onClick: () => {},
+};
+
+TabItem.propTypes = {
+  title: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  activeItem: PropTypes.string,
+  onClick: PropTypes.func,
+};
 
 export default TabItem;

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,0 +1,5 @@
+export const TAB_MENU = [
+  { title: '오늘의 카드', name: 'total' },
+  { title: '나의 카드', name: 'my' },
+  { title: '관심 카드', name: 'like' },
+];

--- a/src/pages/HomePage/index.jsx
+++ b/src/pages/HomePage/index.jsx
@@ -7,11 +7,12 @@ import { cardApi } from '@apis';
 import Swal from 'sweetalert2';
 import { parseCardInfo } from '@utils';
 import { useUser } from '@contexts';
+import { TAB_MENU } from '@constants';
 
 const HomePage = () => {
   const { userInfo } = useUser();
   const [cardList, setCardList] = useState([]);
-  const [cardListName, setCardListName] = useState('');
+  const [cardListName, setCardListName] = useState(TAB_MENU[0].name);
   const [isLoading, setIsLoading] = useState(false);
 
   const getTodayCardList = useCallback(async () => {
@@ -82,17 +83,14 @@ const HomePage = () => {
     const init = async () => {
       if (cardListName === 'total') {
         await getTodayCardList();
-        console.log(cardListName);
         return;
       }
       if (cardListName === 'my') {
         await getMyCardList(userInfo?.id);
-        console.log(cardListName);
         return;
       }
       if (cardListName === 'like') {
         await getBookmarkCardList();
-        console.log(cardListName);
         return;
       }
     };
@@ -108,7 +106,7 @@ const HomePage = () => {
 
   return (
     <HomeContainer>
-      <Tab onClick={handleTabClick} />
+      <Tab onClick={handleTabClick} currentActive={cardListName} />
       <CardsContainer
         myCard={cardListName === 'my'}
         userInfo={userInfo}

--- a/src/styles/mixin.js
+++ b/src/styles/mixin.js
@@ -1,0 +1,11 @@
+import { css } from '@emotion/react';
+import Common from '@styles';
+
+export const tebItemSize = css`
+  width: calc(100% / 3);
+  height: 47px;
+  min-height: 25px;
+  @media ${Common.media.sm} {
+    height: ${47 * 0.68}px;
+  }
+`;


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

Tab컴포넌트 리팩토링 및 상수, mixin 생성 후 적용

## 🧑‍💻 PR 세부 내용
- 모든 스타일 관련 props을 제거하고 고정된 스타일로 수정
- 자식의 상태를 사용하는 경우 props으로 onClick함수를 넘겨주는 방식으로 수정했습니다 
- Tabmenu의 데이터를 상수로 만들어서 적용
- style/mixin파일을 만들어서 중복되는 css코드를 저장해 재사용

## 📸 스크린샷

- 상수 객체의 값을 배열로 만들고 들어온 name에 해당하는 index를 구하기 위해 findIndex함수를 사용했는데 이게 최선일지 모르겠습니다
(탭 포인터를 움직여야하기 때문에 index는 꼭 필요)
  <img width="30%" alt="image" src="https://user-images.githubusercontent.com/81611808/152781529-30a79058-eebe-4657-8b7d-9c142c7ccdbd.png">
  <img width="45%" alt="image" src="https://user-images.githubusercontent.com/81611808/152781626-03276ffe-89ea-486b-abcb-cef76bc0df38.png">

- 현재 style/index.js파일이름을 commn으로 바꾸고 사용된 모든 코드를 수정하고 싶었지만 너무 큰 일이라 
따로 브런치를 하나 파서 작업해야할 것 같습니다

