### PR TITLE
[WC-39] refactor: ScrollGuide컴포넌트 리팩토링 및 Tab관련 코드 수정

### DIFF
--- a/src/components/molecule/ScrollGuide/ScrollGuide.jsx
+++ b/src/components/molecule/ScrollGuide/ScrollGuide.jsx
@@ -95,7 +95,7 @@ const DelButton = styled.div`
 `;
 
 ScrollGuide.defaultProps = {
-  tabStatus: '',
+  tabStatus: 'total',
 };
 
 ScrollGuide.propTypes = {

--- a/src/components/molecule/ScrollGuide/ScrollGuide.jsx
+++ b/src/components/molecule/ScrollGuide/ScrollGuide.jsx
@@ -1,8 +1,37 @@
 import styled from '@emotion/styled';
+import PropTypes from 'prop-types';
 import React, { useState, useEffect } from 'react';
 import { Text, Icons } from '@components';
 import Common from '@styles';
 import useToggle from '@hooks/useToggle';
+
+const ScrollGuide = ({ tabStatus, ...props }) => {
+  const [isVisible, setIsVisible] = useState(tabStatus === 'total');
+  const [isDelete, toggle] = useToggle(false);
+
+  useEffect(() => {
+    setIsVisible(tabStatus === 'total');
+  }, [tabStatus]);
+
+  return (
+    <Container isDelete={isDelete} isVisible={isVisible} {...props}>
+      <DelButton className="del_Button" onClick={toggle}>
+        <Icons fontSize={'10px'}>
+          <Icons.Delete></Icons.Delete>
+        </Icons>
+      </DelButton>
+      <ImgBox>
+        <img
+          src={require('./scroll_guide_icon.png').default}
+          alt="scrollguide"
+        />
+      </ImgBox>
+      <StyledText weight={Common.fontWeight.regular}>
+        Shift+스크롤로 카드들을 둘러보세요!
+      </StyledText>
+    </Container>
+  );
+};
 
 const Container = styled.div`
   position: relative;
@@ -65,37 +94,12 @@ const DelButton = styled.div`
   }
 `;
 
-const ScrollGuide = () => {
-  const [isVisible, setIsVisible] = useState(false);
-  const [isDelete, toggle] = useToggle(false);
+ScrollGuide.defaultProps = {
+  tabStatus: '',
+};
 
-  const currentUrlArr = window.location.pathname.split('/');
-  useEffect(() => {
-    if (currentUrlArr.includes('today') || currentUrlArr[1] === '') {
-      setIsVisible(true);
-      return;
-    }
-    setIsVisible(false);
-  }, [currentUrlArr]);
-
-  return (
-    <Container isDelete={isDelete} isVisible={isVisible}>
-      <DelButton className="del_Button" onClick={toggle}>
-        <Icons fontSize={'10px'}>
-          <Icons.Delete></Icons.Delete>
-        </Icons>
-      </DelButton>
-      <ImgBox>
-        <img
-          src={require('./scroll_guide_icon.png').default}
-          alt="scrollguide"
-        />
-      </ImgBox>
-      <StyledText weight={Common.fontWeight.regular}>
-        Shift+스크롤로 카드들을 둘러보세요!
-      </StyledText>
-    </Container>
-  );
+ScrollGuide.propTypes = {
+  tabStatus: PropTypes.string,
 };
 
 export default ScrollGuide;

--- a/src/components/molecule/ScrollGuide/ScrollGuide.stories.jsx
+++ b/src/components/molecule/ScrollGuide/ScrollGuide.stories.jsx
@@ -1,7 +1,7 @@
 import { ScrollGuide } from '@components';
 
 export default {
-  title: 'Component/Base/ScrollGuide',
+  title: 'Component/molecule/ScrollGuide',
   component: ScrollGuide,
 };
 

--- a/src/components/molecule/Tab/Tab.jsx
+++ b/src/components/molecule/Tab/Tab.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
@@ -11,15 +11,19 @@ import { tebItemSize } from '@styles/mixin';
 const Tab = ({ currentActive, onClick, ...props }) => {
   const [activeItem, setActiveItem] = useState(currentActive);
 
-  const handleClickTabItem = name => {
-    setActiveItem(name);
-    onClick && onClick(name);
-  };
+  const handleClickTabItem = useCallback(
+    name => {
+      setActiveItem(name);
+      onClick && onClick(name);
+    },
+    [onClick],
+  );
 
   return (
     <TabItemContainer {...props}>
       {Object.entries(TAB_MENU).map(([key, value]) => (
         <TabItem
+          key={key}
           title={value}
           name={key}
           activeItem={activeItem}

--- a/src/components/molecule/Tab/Tab.jsx
+++ b/src/components/molecule/Tab/Tab.jsx
@@ -18,21 +18,14 @@ const Tab = ({ currentActive, onClick, ...props }) => {
 
   return (
     <TabItemContainer {...props}>
-      <TabItem
-        title={TAB_MENU[0].title}
-        name={TAB_MENU[0].name}
-        activeItem={activeItem}
-        onClick={handleClickTabItem}></TabItem>
-      <TabItem
-        title={TAB_MENU[1].title}
-        name={TAB_MENU[1].name}
-        activeItem={activeItem}
-        onClick={handleClickTabItem}></TabItem>
-      <TabItem
-        title={TAB_MENU[2].title}
-        name={TAB_MENU[2].name}
-        activeItem={activeItem}
-        onClick={handleClickTabItem}></TabItem>
+      {Object.entries(TAB_MENU).map(([key, value]) => (
+        <TabItem
+          title={value}
+          name={key}
+          activeItem={activeItem}
+          onClick={handleClickTabItem}
+        />
+      ))}
       <TabItemPointer currentActive={activeItem} {...props}></TabItemPointer>
     </TabItemContainer>
   );
@@ -58,9 +51,7 @@ const TabItemPointer = styled.div`
   top: 0;
   transform: ${({ currentActive }) =>
     currentActive &&
-    `translate(${
-      TAB_MENU.findIndex(obj => obj.name === currentActive) * 100
-    }%, 0)`};
+    `translate(${Object.keys(TAB_MENU).indexOf(currentActive) * 100}%, 0)`};
   border: 1px solid ${Common.colors.primary};
   border-radius: 50px;
   background-color: ${rgba(Common.colors.background_menu, 0.2)};

--- a/src/components/molecule/Tab/TabItem.jsx
+++ b/src/components/molecule/Tab/TabItem.jsx
@@ -5,11 +5,11 @@ import { rgba } from 'polished';
 import { tebItemSize } from '@styles/mixin';
 
 const TabItem = ({ title, name, activeItem, onClick, ...props }) => {
-  const handleClick = () => {
+  const handleClickTabItem = () => {
     onClick && onClick(name);
   };
   return (
-    <TabItemWrapper onClick={handleClick} {...props}>
+    <TabItemWrapper onClick={handleClickTabItem} {...props}>
       <LinkBox>
         <TabItemTitle name={name} activeItem={activeItem} {...props}>
           {title}

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,5 +1,5 @@
-export const TAB_MENU = [
-  { title: '오늘의 카드', name: 'total' },
-  { title: '나의 카드', name: 'my' },
-  { title: '관심 카드', name: 'like' },
-];
+export const TAB_MENU = {
+  total: '오늘의 카드',
+  my: '나의 카드',
+  like: '관심 카드',
+};

--- a/src/pages/HomePage/index.jsx
+++ b/src/pages/HomePage/index.jsx
@@ -7,12 +7,11 @@ import { cardApi } from '@apis';
 import Swal from 'sweetalert2';
 import { parseCardInfo } from '@utils';
 import { useUser } from '@contexts';
-import { TAB_MENU } from '@constants';
 
 const HomePage = () => {
   const { userInfo } = useUser();
   const [cardList, setCardList] = useState([]);
-  const [cardListName, setCardListName] = useState(TAB_MENU[0].name);
+  const [cardListName, setCardListName] = useState('total');
   const [isLoading, setIsLoading] = useState(false);
 
   const getTodayCardList = useCallback(async () => {

--- a/src/pages/HomePage/index.jsx
+++ b/src/pages/HomePage/index.jsx
@@ -99,20 +99,20 @@ const HomePage = () => {
     // eslint-disable-next-line
   }, [cardListName]);
 
-  const handleTabClick = name => {
+  const handleClickTab = useCallback(name => {
     setCardListName(name);
-  };
+  }, []);
 
   return (
     <HomeContainer>
-      <Tab onClick={handleTabClick} currentActive={cardListName} />
+      <Tab onClick={handleClickTab} currentActive={cardListName} />
       <CardsContainer
         myCard={cardListName === 'my'}
         userInfo={userInfo}
         cardList={cardList}
         currentParam={cardListName}
       />
-      <ScrollGuide class="scroll_guide" />
+      <ScrollGuide tabStatus={cardListName} />
       <Spinner loading={isLoading} />
       <Outlet />
     </HomeContainer>


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

ScrollGuide컴포넌트 리팩토링 및 Tab관련 코드 수정

## 🧑‍💻 PR 세부 내용
- ScrollGuide렌더링 조건을 url에서 props으로 받은 Tab name으로 수정(HomePage에서 Tab이 total일 때만 렌더링되도록)
- Tab 데이터 상수를 객체로 수정하고 관련 코드에 적용
- Tab 관련 handler함수들에 useCallback적용

**ScrollGuide**
<img width="357" alt="image" src="https://user-images.githubusercontent.com/81611808/152939202-70037b5c-747c-4989-956c-47915a687a4a.png">

**Tab**
<img width="30%" alt="image" src="https://user-images.githubusercontent.com/81611808/152938947-ddab08f4-aac6-4625-aa8a-de10814d429d.png">
<img width="50%" alt="image" src="https://user-images.githubusercontent.com/81611808/152939007-5f52ae0d-3a8b-48f4-875e-45ef2196c899.png">
<img width="50%" alt="image" src="https://user-images.githubusercontent.com/81611808/152939035-146c5de4-5d7d-4b48-a37e-9c92674714af.png">

## 논의 사항
- HomePage에서 ScrollGuide, Tab관련 코드만 살짝 수정했는데 괜찮을까요??
- 홈페이지 사이드 여백 수정: CardContainer스타일부분 코드 건드려야해서 일단 냅뒀습니다
- 가이드페이지: 연결하려했는데 그냥 빈 container만 있어서 새로 만들어야할 것 같습니다(그래도 있는 게 낫겠죠??)
