### PR TITLE
[WC-49] refactor:  Header리팩토링 및 text, Header ts적용

### DIFF
--- a/src/components/atom/Text/Text.tsx
+++ b/src/components/atom/Text/Text.tsx
@@ -1,6 +1,17 @@
+import type { HTMLAttributes } from 'react';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 import Common from '@/styles';
+
+interface TextProps extends HTMLAttributes<HTMLElement> {
+  children: React.ReactNode;
+  block?: boolean;
+  paragraph?: boolean;
+  size?: string | number;
+  weight?: string | number;
+  color?: string;
+  underline?: boolean;
+  del?: boolean;
+}
 
 const Text = ({
   children,
@@ -12,7 +23,7 @@ const Text = ({
   underline = false,
   del = false,
   ...props
-}) => {
+}: TextProps): JSX.Element => {
   if (!underline && del) {
     children = <del>{children}</del>;
   }
@@ -24,7 +35,7 @@ const Text = ({
 
   const Tag = block ? 'div' : paragraph ? 'p' : 'span';
 
-  const StyledTag = styled(Tag)`
+  const StyledTag = styled(Tag)<TextProps>`
     font-size: ${({ size }) => (typeof size === 'number' ? `${size}px` : size)};
     font-weight: ${({ weight }) => weight};
     color: ${({ color }) => color};
@@ -44,17 +55,6 @@ const Text = ({
       {children}
     </StyledTag>
   );
-};
-
-Text.propTypes = {
-  children: PropTypes.node.isRequired,
-  block: PropTypes.bool,
-  paragraph: PropTypes.bool,
-  size: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-  weight: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-  color: PropTypes.string,
-  underline: PropTypes.bool,
-  del: PropTypes.bool,
 };
 
 export default Text;

--- a/src/components/organism/Header/Header.tsx
+++ b/src/components/organism/Header/Header.tsx
@@ -3,11 +3,52 @@ import styled from '@emotion/styled';
 import Common from '@/styles';
 import PropTypes from 'prop-types';
 import { useNavigate } from 'react-router-dom';
-import { Icons, Text } from '@/components';
+import { Text } from '@/components';
 import { rgba } from 'polished';
 import { userState } from '@/recoils';
 import { useRecoilValue } from 'recoil';
 import { logo } from '@/images';
+import HelpIcon from '@mui/icons-material/Help';
+import PersonIcon from '@mui/icons-material/Person';
+
+const Header = ({ ...props }): JSX.Element => {
+  const userInfo = useRecoilValue(userState);
+  const navigate = useNavigate();
+
+  return (
+    <HeaderTag {...props}>
+      <Logo
+        onClick={() => {
+          navigate('/');
+        }}
+      >
+        <img src={logo} alt="logo" />
+      </Logo>
+      <UtilIconBox>
+        <StyledHelpIcon
+          onClick={() => {
+            navigate('/guide');
+          }}
+        />
+        {userInfo ? (
+          <StyledPersonIcon
+            onClick={() => {
+              navigate('/my-page');
+            }}
+          />
+        ) : (
+          <StyleTextLogin
+            onClick={() => {
+              navigate('/login');
+            }}
+          >
+            로그인
+          </StyleTextLogin>
+        )}
+      </UtilIconBox>
+    </HeaderTag>
+  );
+};
 
 const HeaderTag = styled.header`
   position: fixed;
@@ -18,7 +59,7 @@ const HeaderTag = styled.header`
   align-items: center;
   height: 60px;
   padding: 0 50px;
-  background-color: ${({ backgroundColor }) => backgroundColor};
+  background-color: ${Common.colors.background};
   @media ${Common.media.sm} {
     padding: 0 16px;
   }
@@ -27,6 +68,7 @@ const HeaderTag = styled.header`
 const Logo = styled.h1`
   margin: 0;
   font-size: 0;
+  cursor: pointer;
   img {
     width: auto;
     height: 30px;
@@ -42,22 +84,18 @@ const UtilIconBox = styled.div`
   align-items: center;
 `;
 
-const HelpIcon = styled.span`
+const StyledHelpIcon = styled(HelpIcon)`
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 24px;
-  height: 24px;
+  font-size: 1.7rem;
   border-radius: 50px;
-  font-size: 14px;
-  margin-right: 10px;
-  color: rgba(255, 255, 255, 0.8);
-  background-color: rgba(255, 255, 255, 0.15);
+  margin-right: 12px;
+  color: rgba(255, 255, 255, 0.4);
   cursor: pointer;
   transition: all 150ms ease-out;
   &:hover {
-    color: rgba(255, 255, 255, 1);
-    background-color: rgba(255, 255, 255, 0.35);
+    color: rgba(255, 255, 255, 0.8);
   }
   @media ${Common.media.sm} {
     margin-right: 8px;
@@ -72,7 +110,7 @@ const StyleTextLogin = styled(Text)`
   }
 `;
 
-const StyledIcon = styled(Icons.Person)`
+const StyledPersonIcon = styled(PersonIcon)`
   color: ${Common.colors.point};
   font-size: 20px;
   transition: color 0.2s ease-out;
@@ -86,51 +124,6 @@ const StyledIcon = styled(Icons.Person)`
     color: ${rgba(Common.colors.point, 0.7)};
   }
 `;
-
-const Header = ({ backgroundColor = Common.colors.background, ...props }) => {
-  const userInfo = useRecoilValue(userState);
-  const navigate = useNavigate();
-
-  return (
-    <HeaderTag backgroundColor={backgroundColor} {...props}>
-      <Logo
-        onClick={() => {
-          navigate('/');
-        }}
-      >
-        <img src={logo} alt="logo" />
-      </Logo>
-      <UtilIconBox>
-        <HelpIcon
-          onClick={() => {
-            navigate('/guide');
-          }}
-        >
-          ❔
-        </HelpIcon>
-        {userInfo ? (
-          <StyledIcon
-            onClick={() => {
-              navigate('/my-page');
-            }}
-            color={Common.colors.point}
-          />
-        ) : (
-          <StyleTextLogin
-            color={Common.colors.point}
-            size={Common.fontSize.regular}
-            weight={Common.fontWeight.regular}
-            onClick={() => {
-              navigate('/login');
-            }}
-          >
-            로그인
-          </StyleTextLogin>
-        )}
-      </UtilIconBox>
-    </HeaderTag>
-  );
-};
 
 Header.propTypes = {
   backgroundColor: PropTypes.string,

--- a/src/components/organism/Header/Header.tsx
+++ b/src/components/organism/Header/Header.tsx
@@ -11,12 +11,12 @@ import { logo } from '@/images';
 import HelpIcon from '@mui/icons-material/Help';
 import PersonIcon from '@mui/icons-material/Person';
 
-const Header = ({ ...props }): JSX.Element => {
+const Header = (): JSX.Element => {
   const userInfo = useRecoilValue(userState);
   const navigate = useNavigate();
 
   return (
-    <HeaderTag {...props}>
+    <HeaderTag>
       <Logo
         onClick={() => {
           navigate('/');


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

Header리팩토링 및 text, Header ts적용

## 🧑‍💻 PR 세부 내용
- 로고에 cursor적용
- 기존에 사용한 icon컴포넌트를 mui import로 변경
- 물음표 텍스트 아이콘으로 변경
- Header, Text컴포넌트 tsx로 전환

## 📸 스크린샷

<img width="84" alt="image" src="https://user-images.githubusercontent.com/81611808/154420153-0cce4911-bec4-434f-9345-25f062d5518d.png">
