### PR TITLE
[WC-63] refactor: axios 응답의 데이터 타입 명시

### DIFF
--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -7,7 +7,7 @@ interface UserApiType {
     name: string;
     email: string;
     password: string;
-  }) => Promise<AxiosResponse>;
+  }) => Promise<AxiosResponse<UserType>>;
   login: (userInfo: {
     email: string;
     password: string;
@@ -19,7 +19,7 @@ interface UserApiType {
   }: {
     name?: string;
     password?: string;
-  }) => Promise<AxiosResponse>;
+  }) => Promise<AxiosResponse<UserType>>;
 }
 
 const userApi: UserApiType = {

--- a/src/apis/comment.ts
+++ b/src/apis/comment.ts
@@ -1,11 +1,20 @@
 import { AxiosResponse } from 'axios';
 import { request, authRequest } from './request';
+import { CommentType } from '@/types';
 
 interface CommentApiType {
-  getCommentsByWaffleCardId: (waffleCardId: string) => Promise<AxiosResponse>;
-  getCommentById: (id: string) => Promise<AxiosResponse>;
-  createComment: (waffleCardId: string, text: string) => Promise<AxiosResponse>;
-  updateComment: (id: string, text: string) => Promise<AxiosResponse>;
+  getCommentsByWaffleCardId: (
+    waffleCardId: string,
+  ) => Promise<AxiosResponse<CommentType[]>>;
+  getCommentById: (id: string) => Promise<AxiosResponse<CommentType>>;
+  createComment: (
+    waffleCardId: string,
+    text: string,
+  ) => Promise<AxiosResponse<CommentType>>;
+  updateComment: (
+    id: string,
+    text: string,
+  ) => Promise<AxiosResponse<CommentType>>;
   deleteComment: (id: string) => Promise<AxiosResponse>;
 }
 

--- a/src/apis/like.ts
+++ b/src/apis/like.ts
@@ -1,8 +1,9 @@
 import { AxiosResponse } from 'axios';
 import { authRequest } from './request';
+import { LikeType } from '@/types';
 
 interface LikeApiType {
-  createLike: (waffleCardId: string) => Promise<AxiosResponse>;
+  createLike: (waffleCardId: string) => Promise<AxiosResponse<LikeType>>;
   deleteLike: (waffleCardId: string) => Promise<AxiosResponse>;
 }
 

--- a/src/apis/waffleCard.ts
+++ b/src/apis/waffleCard.ts
@@ -13,10 +13,9 @@ interface WaffleCardApiType {
     emoji,
     color,
     hashTags,
-  }: Pick<
-    WaffleCardType,
-    'emoji' | 'color' | 'hashTags'
-  >) => Promise<AxiosResponse>;
+  }: Pick<WaffleCardType, 'emoji' | 'color' | 'hashTags'>) => Promise<
+    AxiosResponse<WaffleCardType>
+  >;
   updateWaffleCard: (
     waffleCardId: string,
     {
@@ -24,7 +23,7 @@ interface WaffleCardApiType {
       color,
       hashTags,
     }: Pick<WaffleCardType, 'emoji' | 'color' | 'hashTags'>,
-  ) => Promise<AxiosResponse>;
+  ) => Promise<AxiosResponse<WaffleCardType>>;
   deleteWaffleCard: (
     waffleCardId: Pick<WaffleCardType, 'id'>,
   ) => Promise<AxiosResponse>;

--- a/src/types/comment.ts
+++ b/src/types/comment.ts
@@ -1,0 +1,11 @@
+export type CommentType = {
+  id: string;
+  user: {
+    id: string;
+    name: string;
+  };
+  waffleCardId: string;
+  text: string;
+  createdAt: string;
+  updatedAt: string;
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,3 +2,4 @@ export type { UserType } from './user';
 export type { WaffleCardType } from './waffleCard';
 export type { ModalsStateType } from './modals';
 export type { CommentType } from './comment';
+export type { LikeType } from './like';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,4 @@
 export type { UserType } from './user';
 export type { WaffleCardType } from './waffleCard';
 export type { ModalsStateType } from './modals';
+export type { CommentType } from './comment';

--- a/src/types/like.ts
+++ b/src/types/like.ts
@@ -1,0 +1,5 @@
+export type LikeType = {
+  id: string;
+  userId: string;
+  waffleCardId: string;
+};


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

axios 응답의 데이터 타입 명시

## 🧑‍💻 PR 세부 내용

- axios 응답의 데이터 타입이 any인 현상을 발견하여 응답의 데이터 타입을 명시하였습니다.
- 'LikeType', 'CommentType'을 추가로 명시하였습니다.

#### LikeType
```js
export type LikeType = {
  id: string;
  userId: string;
  waffleCardId: string;
};

```

#### CommentType
```js
export type CommentType = {
  id: string;
  user: {
    id: string;
    name: string;
  };
  waffleCardId: string;
  text: string;
  createdAt: string;
  updatedAt: string;
};


```
